### PR TITLE
Fix GitHub Pages deployment for frontend

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,20 +27,12 @@ jobs:
         run: |
           npm ci
           npm run build
-
-      - name: Prepare Pages artifact
-        run: |
-          rm -rf public
-          mkdir public
-          # Copy the build output
-          cp -r frontend/ipl-analyzer-frontend/build/. public/
-          # Disable Jekyll processing
-          touch public/.nojekyll
+          touch dist/.nojekyll # Add .nojekyll to the build output directory
 
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: public
+          path: frontend/ipl-analyzer-frontend/dist # Point directly to Vite's output
 
       - uses: actions/deploy-pages@v4

--- a/frontend/ipl-analyzer-frontend/vite.config.ts
+++ b/frontend/ipl-analyzer-frontend/vite.config.ts
@@ -4,6 +4,7 @@ import { configDefaults } from 'vitest/config'; // Import configDefaults
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/ipl-analyser/',
   plugins: [react()],
   test: {
     globals: true, // Optional: to use Vitest globals like describe, it, expect without importing


### PR DESCRIPTION
This commit addresses issues with deploying the frontend application to GitHub Pages.

Key changes:
- Updated `vite.config.ts` to set the `base` path to `/ipl-analyser/`. This ensures that assets are loaded correctly when the site is served from a subdirectory on GitHub Pages.
- Modified the `.github/workflows/pages.yml` workflow:
    - Corrected the build output directory to point to `frontend/ipl-analyzer-frontend/dist/`, which is the default for Vite.
    - Simplified the artifact preparation process by having the `upload-pages-artifact` action directly use the build output directory.
    - Ensured that a `.nojekyll` file is created in the build output directory to prevent Jekyll processing by GitHub Pages.

These changes should allow the frontend to be deployed and displayed correctly on GitHub Pages.