### PR TITLE
Fix TypeScript errors, build issues, and deployment base path

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { team_full_names, team_styles } from '../teamStyles'; import type { TeamNames, TeamStyle } from '../teamStyles';
+import { team_full_names, team_styles } from '../teamStyles'; import type { TeamStyle } from '../teamStyles';
 interface TeamStats {
   Matches: number;
   Wins: number;
@@ -104,9 +104,9 @@ const CurrentStandings: React.FC = () => {
           </thead>
           <tbody>
             {standings.map((team) => {
-              const style = team_styles[team.teamKey] as TeamStyle | undefined || {};
+              const teamStyle = team_styles[team.teamKey] as TeamStyle | undefined;
               return (
-                <tr key={team.teamKey} style={{ backgroundColor: style.bg, color: style.text }}>
+                <tr key={team.teamKey} style={{ backgroundColor: teamStyle?.bg || '#FFFFFF', color: teamStyle?.text || '#000000' }}>
                   <td>{team.pos}</td>
                   <td>{team.teamFullName}</td>
                   <td>{team.Matches}</td>

--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.test.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+/// <reference types="vitest/globals" />
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'; // Removed 'vi'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import DetailedTeamAnalysis from './DetailedTeamAnalysis'; // Adjust path as needed
 // team_full_names is imported by the component, so we mock it at the module level
@@ -33,11 +34,12 @@ const mockAnalysisData = {
 };
 
 describe('DetailedTeamAnalysis Component', () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>;
+  let fetchSpy: vi.MockInstance<[RequestInfo | URL, RequestInit?], Promise<Response>>;
 
   beforeEach(() => {
     // Ensure fetch is mocked for each test
-    fetchSpy = vi.spyOn(window, 'fetch');
+    fetchSpy = vi.fn(); // Create a generic mock function
+    globalThis.fetch = fetchSpy as any; // Assign it to globalThis.fetch
   });
 
   afterEach(() => {
@@ -45,7 +47,7 @@ describe('DetailedTeamAnalysis Component', () => {
   });
 
   const setupFetchMock = (data: any, ok = true) => {
-    fetchSpy.mockImplementation((url) => {
+    fetchSpy.mockImplementation((url: RequestInfo | URL) => { // Add type to url
       if (typeof url === 'string' && url.endsWith('/analysis_results.json')) {
         return Promise.resolve({
           ok: ok,

--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { team_full_names, team_short_names } from '../teamStyles'; import type { TeamNames } from '../teamStyles';
+import { team_full_names } from '../teamStyles'; import type { TeamNames } from '../teamStyles';
 
 
 interface TeamAnalysisResult {
@@ -186,7 +186,7 @@ const DetailedTeamAnalysis: React.FC = () => {
                     {fixtureOutcomes.map((item, index) => (
                       <tr key={index}>
                         <td>{item.fixture}</td>
-                        <td>{item.outcome.Outcome}</td>
+                        <td>{item.outcome}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -2,10 +2,21 @@ import React, { useEffect, useState } from 'react';
 
 import { team_full_names, team_styles } from '../teamStyles'; import type { TeamNames, TeamStyle } from '../teamStyles';
 
+// Copied from CurrentStandings.tsx
+interface TeamStats {
+  Matches: number;
+  Wins: number;
+  Points: number;
+}
+
+// Copied from CurrentStandings.tsx
+interface StandingsData {
+  [key: string]: TeamStats;
+}
 
 // Types specific to this component's data fetching needs, not directly used by runSimulation
 interface FetchedStandingsData {
-  standings: StandingsData; // This type is now from simulationLogic
+  standings: StandingsData;
 }
 
 interface TeamAnalysisResult {
@@ -49,7 +60,6 @@ const runSimulation = (
   const matchLog: string[] = [];
 
   for (const fixture in resultsDf) {
-    const outcome = resultsDf[fixture];
     const teams = fixture.split(" vs ");
     if (teams.length !== 2) {
       matchLog.push(`Invalid fixture string: ${fixture}`);
@@ -61,8 +71,8 @@ const runSimulation = (
     let winner: string;
     let loser: string;
 
-    const outcomeObject = resultsDf[fixture];
-    const outcomeString = outcomeObject.Outcome;
+    const outcomeObject = resultsDf[fixture]; // This is the outcome string
+    const outcomeString = outcomeObject; // Corrected: outcomeObject is the string itself
     if (outcomeString.includes("wins")) {
       winner = outcomeString.replace(" wins", "");
       loser = winner === teamA ? teamB : teamA;
@@ -268,9 +278,9 @@ const ScenarioSimulation: React.FC = () => {
                   </thead>
                   <tbody>
                     {simulatedFinalStandings.map((team) => {
-                      const style = team_styles[team.teamKey] as TeamStyle | undefined || {};
+                      const teamStyle = team_styles[team.teamKey] as TeamStyle | undefined;
                       return (
-                        <tr key={team.teamKey} style={{ backgroundColor: style.bg, color: style.text }}>
+                        <tr key={team.teamKey} style={{ backgroundColor: teamStyle?.bg || '#FFFFFF', color: teamStyle?.text || '#000000' }}>
                           <td>{team.pos}</td>
                           <td>{team.teamFullName}</td>
                           <td>{team.Matches}</td>

--- a/frontend/ipl-analyzer-frontend/src/utils/simulationLogic.test.ts
+++ b/frontend/ipl-analyzer-frontend/src/utils/simulationLogic.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { runSimulation } from './simulationLogic';
-import type { StandingsData, SimulatedTeamStats } from './simulationLogic';
+import type { StandingsData } from './simulationLogic';
 
 // Mock team_full_names used by the runSimulation function for teamFullName property
 // This avoids depending on the actual teamStyles.ts file in these unit tests.

--- a/frontend/ipl-analyzer-frontend/tsconfig.app.json
+++ b/frontend/ipl-analyzer-frontend/tsconfig.app.json
@@ -24,7 +24,16 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src", "src/setupTests.ts"] // Added setupTests.ts
+  "include": ["src", "src/setupTests.ts"], // Added setupTests.ts
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/__tests__/*",
+    "src/**/__mocks__/*"
+  ]
 }
 // Note: vite.config.ts is typically handled by tsconfig.node.json or processed by Vite directly,
 // so it's usually not needed in tsconfig.app.json's include array.

--- a/frontend/ipl-analyzer-frontend/vite.config.ts
+++ b/frontend/ipl-analyzer-frontend/vite.config.ts
@@ -4,7 +4,7 @@ import { configDefaults } from 'vitest/config'; // Import configDefaults
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/ipl-analyser/',
+  base: '/ipl_top4_analysis/',
   plugins: [react()],
   test: {
     globals: true, // Optional: to use Vitest globals like describe, it, expect without importing


### PR DESCRIPTION
This commit includes several fixes:

1.  **TypeScript Error Resolution**:
    - Corrected various TypeScript errors across components: - `CurrentStandings.tsx`: Removed unused imports, safe style access. - `DetailedTeamAnalysis.test.tsx`: Changed `window.fetch` spy to `globalThis.fetch`. - `DetailedTeamAnalysis.tsx`: Removed unused imports, corrected outcome property access. - `ScenarioSimulation.tsx`: Defined missing types (`TeamStats`, `StandingsData`), removed unused variables, corrected property access for outcomes and styles, ensured `SimulatedTeamStats` properties were accessed correctly. - `simulationLogic.test.ts`: Removed unused import.

2.  **Build Configuration (`tsc -b`)**:
    - Updated `frontend/ipl-analyzer-frontend/tsconfig.app.json` to exclude test files (`*.test.tsx`, `*.test.ts`, etc.) from the `tsc -b` compilation. This resolves the "Cannot find namespace 'vi'" error that occurred when `tsc -b` attempted to compile Vitest-specific test files.

3.  **GitHub Pages Deployment**:
    - Updated `frontend/ipl-analyzer-frontend/vite.config.ts` to set the `base` path to `/ipl_top4_analysis/` to match the repository name and ensure correct asset loading on GitHub Pages.

These changes ensure the project builds successfully and is correctly configured for deployment to GitHub Pages.