### PR TITLE
I've corrected the paths used to fetch `current_standings.json` and `…

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
@@ -31,7 +31,7 @@ const CurrentStandings: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch('/current_standings.json')
+    fetch(`${import.meta.env.BASE_URL}current_standings.json`)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -44,7 +44,7 @@ const DetailedTeamAnalysis: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch('/analysis_results.json')
+    fetch(`${import.meta.env.BASE_URL}analysis_results.json`)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -138,8 +138,8 @@ const ScenarioSimulation: React.FC = () => {
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      fetch('/current_standings.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch('/analysis_results.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
+      fetch(`${import.meta.env.BASE_URL}analysis_results.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
…analysis_results.json` to fix the 404 errors for JSON data files on GitHub Pages. The fetch calls now prepend `import.meta.env.BASE_URL` to ensure that the paths are resolved correctly relative to the deployment base path (`/ipl_top4_analysis/`) on GitHub Pages.

This change affects:
- `frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx`
- `frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx`
- `frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx`

These updates should resolve the 404 errors you previously encountered when trying to load these data files after deployment.