### PR TITLE
Fix React rendering and runtime errors

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -4,7 +4,7 @@ import { team_full_names } from '../teamStyles'; import type { TeamNames } from 
 
 interface TeamAnalysisResult {
   percentage: number;
-  results_df: { [fixture: string]: string };
+  results_df: { [fixture: string]: { Outcome: string; [key: string]: any } }; // Updated
 }
 
 interface TeamAnalysisData {
@@ -27,7 +27,7 @@ interface FetchedAnalysisData {
 
 interface FixtureOutcome {
   fixture: string;
-  outcome: string;
+  outcome: { Outcome: string; [key: string]: any }; // Updated
 }
 
 const DetailedTeamAnalysis: React.FC = () => {
@@ -186,7 +186,7 @@ const DetailedTeamAnalysis: React.FC = () => {
                     {fixtureOutcomes.map((item, index) => (
                       <tr key={index}>
                         <td>{item.fixture}</td>
-                        <td>{item.outcome}</td>
+                        <td>{item.outcome.Outcome}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -21,7 +21,7 @@ interface FetchedStandingsData {
 
 interface TeamAnalysisResult {
   percentage: number;
-  results_df: { [fixture: string]: string };
+  results_df: { [fixture: string]: { Outcome: string; [key: string]: any } }; // Updated type
 }
 
 interface TeamAnalysisData {
@@ -53,7 +53,7 @@ interface SimulatedTeamStats extends TeamStats {
 // Helper function for simulation
 const runSimulation = (
   initialStandings: StandingsData,
-  resultsDf: { [fixture: string]: string },
+  resultsDf: { [fixture: string]: { Outcome: string; [key: string]: any } }, // Updated parameter type
   analyzedTeamKey: string
 ): { matchLog: string[]; finalStandings: SimulatedTeamStats[] } => {
   const currentStandings = JSON.parse(JSON.stringify(initialStandings)); // Deep copy
@@ -71,8 +71,8 @@ const runSimulation = (
     let winner: string;
     let loser: string;
 
-    const outcomeObject = resultsDf[fixture]; // This is the outcome string
-    const outcomeString = outcomeObject; // Corrected: outcomeObject is the string itself
+    const outcomeObject = resultsDf[fixture]; // outcomeObject is now an object
+    const outcomeString = outcomeObject.Outcome; // Extract Outcome property
     if (outcomeString.includes("wins")) {
       winner = outcomeString.replace(" wins", "");
       loser = winner === teamA ? teamB : teamA;


### PR DESCRIPTION
This commit addresses two main issues:

1.  **React Error #31 in `DetailedTeamAnalysis.tsx`**:
    - I fixed an error where an object `{ Outcome: "..." }` was being rendered directly as a React child.
    - I changed `item.outcome` to `item.outcome.Outcome` in the rendering logic to correctly display the outcome string.

2.  **Potential Runtime Error in `ScenarioSimulation.tsx`**:
    - I corrected the processing of fixture outcomes from `analysis_results.json`.
    - I changed `const outcomeString = outcomeObject;` to `const outcomeString = outcomeObject.Outcome;` to ensure string methods are called on strings.
    - I updated the type definition for `results_df` in `TeamAnalysisResult` interface to expect outcome objects (`{ Outcome: string; ... }`) instead of plain strings.

These changes should resolve the blank page issue and allow your application to render correctly with the fetched data.