### PR TITLE
It looks like the refactoring of fetch calls to use the URL construct…

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
@@ -31,7 +31,7 @@ const CurrentStandings: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`${import.meta.env.BASE_URL}current_standings.json`)
+    fetch(new URL('current_standings.json', import.meta.env.BASE_URL).href)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -44,7 +44,7 @@ const DetailedTeamAnalysis: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`${import.meta.env.BASE_URL}analysis_results.json`)
+    fetch(new URL('analysis_results.json', import.meta.env.BASE_URL).href)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -138,8 +138,8 @@ const ScenarioSimulation: React.FC = () => {
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch(`${import.meta.env.BASE_URL}analysis_results.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      fetch(new URL('current_standings.json', import.meta.env.BASE_URL).href).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
+      fetch(new URL('analysis_results.json', import.meta.env.BASE_URL).href).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
…or is complete.

I updated the fetch calls for JSON data files (`current_standings.json`, `analysis_results.json`) to use `new URL('filename.json', import.meta.env.BASE_URL).href`.

This approach provides a more robust way to construct absolute URLs from a base path and a relative file path, ensuring correct path resolution regardless of trailing slashes or other variations in `import.meta.env.BASE_URL`.

This change affects:
- `frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx`
- `frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx`
- `frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx`

This is an attempt to resolve persistent 404 errors for these files when deployed on GitHub Pages.