### PR TITLE
Revert fetch calls to use string concatenation

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/CurrentStandings.tsx
@@ -31,7 +31,7 @@ const CurrentStandings: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(new URL('current_standings.json', import.meta.env.BASE_URL).href)
+    fetch(`${import.meta.env.BASE_URL}current_standings.json`)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -44,7 +44,7 @@ const DetailedTeamAnalysis: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(new URL('analysis_results.json', import.meta.env.BASE_URL).href)
+    fetch(`${import.meta.env.BASE_URL}analysis_results.json`)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -138,8 +138,8 @@ const ScenarioSimulation: React.FC = () => {
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      fetch(new URL('current_standings.json', import.meta.env.BASE_URL).href).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch(new URL('analysis_results.json', import.meta.env.BASE_URL).href).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
+      fetch(`${import.meta.env.BASE_URL}analysis_results.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
I reverted the changes that used `new URL('filename.json', import.meta.env.BASE_URL).href` for fetch calls. The `URL` constructor's second argument (base) must be an absolute URL, and `import.meta.env.BASE_URL` is a path, which caused "Invalid base URL" errors.

The fetch calls now use the original method:
`fetch(\`\${import.meta.env.BASE_URL}filename.json\`)`

This may resurface the 404 errors for JSON files if the underlying issue of `import.meta.env.BASE_URL` evaluating to an empty string in the bundled code persists. Further investigation will be needed if 404s continue.