### PR TITLE
For diagnostic purposes, the fetch call for `analysis_results.json` i…

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -44,7 +44,7 @@ const DetailedTeamAnalysis: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`${import.meta.env.BASE_URL}analysis_results.json`)
+    fetch('/ipl_top4_analysis/analysis_results.json')
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
…n `DetailedTeamAnalysis.tsx` has been temporarily changed to use a hardcoded path: `fetch('/ipl_top4_analysis/analysis_results.json')`.

This is to determine if the persistent 404 errors you're seeing are related to the `import.meta.env.BASE_URL` variable or some other aspect of path resolution in the deployed environment.

This change is intended to be temporary.