### PR TITLE
To diagnose the issue, I've adjusted the fetch calls in `ScenarioSimu…

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -139,8 +139,8 @@ const ScenarioSimulation: React.FC = () => {
     console.log('ScenarioSimulation.tsx - BASE_URL for analysis_results:', import.meta.env.BASE_URL);
     setLoading(true);
     Promise.all([
-      fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch(`${import.meta.env.BASE_URL}analysis_results.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      fetch('current_standings.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
+      fetch('analysis_results.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
…lation.tsx`. They now use simple relative paths, like `'analysis_results.json'`, instead of including `import.meta.env.BASE_URL`.

This change will help me test if the browser's native relative path resolution from the current page URL (`/ipl_top4_analysis/`) can correctly fetch the JSON files. This way, I can bypass any potential problems related to the `BASE_URL` substitution.