### PR TITLE
I've added a base tag to `index.html` to ensure robust path resolution.

### DIFF
--- a/frontend/ipl-analyzer-frontend/index.html
+++ b/frontend/ipl-analyzer-frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <base href="/ipl_top4_analysis/" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -139,8 +139,8 @@ const ScenarioSimulation: React.FC = () => {
     console.log('ScenarioSimulation.tsx - BASE_URL for analysis_results:', import.meta.env.BASE_URL);
     setLoading(true);
     Promise.all([
-      fetch('current_standings.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch('analysis_results.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
+      fetch(`${import.meta.env.BASE_URL}analysis_results.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
Specifically, I manually added `<base href="/ipl_top4_analysis/">` to the source file `frontend/ipl-analyzer-frontend/index.html`. This tag will be preserved in the built `dist/index.html` and ensures that all relative path resolutions within your application (including fetch calls for JSON data) are correctly based from the `/ipl_top4_analysis/` sub-path.

Fetch calls in `ScenarioSimulation.tsx` that were changed to relative paths for diagnostic purposes have been reverted to use `${import.meta.env.BASE_URL}filename.json`.

This combination should provide robust path handling for assets and data files when deployed to GitHub Pages under a sub-path.