### PR TITLE
Diagnose: Use full hardcoded URL for fetch

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -140,7 +140,7 @@ const ScenarioSimulation: React.FC = () => {
     setLoading(true);
     Promise.all([
       fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch(`${import.meta.env.BASE_URL}analysis_results.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      fetch('https://rakeshnreddy.github.io/ipl_top4_analysis/analysis_results.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
For diagnostic purposes, the fetch call for `analysis_results.json` in `ScenarioSimulation.tsx` has been temporarily changed to use the full hardcoded URL:
`fetch('https://rakeshnreddy.github.io/ipl_top4_analysis/analysis_results.json')`.

This is to determine if JavaScript's fetch can access this specific URL, bypassing all relative/absolute path logic and environment variables.