### PR TITLE
I've added more detailed console.log statements in `DetailedTeamAnaly…

### DIFF
--- a/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/DetailedTeamAnalysis.tsx
@@ -44,7 +44,11 @@ const DetailedTeamAnalysis: React.FC = () => {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`${import.meta.env.BASE_URL}analysis_results.json`)
+    const analysisFile = 'analysis_results.json';
+    console.log('DetailedTeamAnalysis.tsx - Fetching filename:', analysisFile);
+    const constructedURL = `${import.meta.env.BASE_URL}${analysisFile}`;
+    console.log('DetailedTeamAnalysis.tsx - Constructed URL for analysis_results:', constructedURL);
+    fetch(constructedURL)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
+++ b/frontend/ipl-analyzer-frontend/src/components/ScenarioSimulation.tsx
@@ -140,7 +140,16 @@ const ScenarioSimulation: React.FC = () => {
     setLoading(true);
     Promise.all([
       fetch(`${import.meta.env.BASE_URL}current_standings.json`).then(res => res.ok ? res.json() : Promise.reject(new Error(`Standings fetch error: ${res.status}`))),
-      fetch('https://rakeshnreddy.github.io/ipl_top4_analysis/analysis_results.json').then(res => res.ok ? res.json() : Promise.reject(new Error(`Analysis fetch error: ${res.status}`)))
+      (() => {
+        const analysisFile = 'analysis_results.json';
+        console.log('ScenarioSimulation.tsx - Fetching filename:', analysisFile);
+        const constructedURL = `${import.meta.env.BASE_URL}${analysisFile}`;
+        console.log('ScenarioSimulation.tsx - Constructed URL for analysis_results:', constructedURL);
+        return fetch(constructedURL).then(res => {
+          if (!res.ok) throw new Error(`Analysis fetch error: ${res.status}`);
+          return res.json();
+        });
+      })()
     ])
     .then(([standingsResult, analysisResult]: [FetchedStandingsData, FetchedAnalysisData]) => {
       if (!standingsResult.standings) {


### PR DESCRIPTION
…sis.tsx` and `ScenarioSimulation.tsx` right before the fetch calls for `analysis_results.json`.

These logs will output:
1. The literal filename being used.
2. The `import.meta.env.BASE_URL` value at that point.
3. The fully constructed URL string that will be passed to fetch.

This will give us maximum visibility into the exact URL being constructed by the JavaScript code at runtime. We can then compare this with the actual network request URL reported by the browser, in an effort to pinpoint the cause of the persistent 404 errors.